### PR TITLE
Custom pkgs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: promote
 Type: Package
 Title: Client for the 'Alteryx Promote' API
 Version: 1.1.0
-Date: 2018-04-20    
+Date: 2018-11-05    
 Author: Paul E. Promote <promotedev@alteryx.com>
 Maintainer: Paul E. Promote <promotedev@alteryx.com>
 Description: Deploy, maintain, and invoke predictive models using the 'Alteryx

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: promote
 Type: Package
 Title: Client for the 'Alteryx Promote' API
 Version: 1.1.0
-Date: 2018-11-05    
+Date: 2018-11-07    
 Author: Paul E. Promote <promotedev@alteryx.com>
 Maintainer: Paul E. Promote <promotedev@alteryx.com>
 Description: Deploy, maintain, and invoke predictive models using the 'Alteryx

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: promote
 Type: Package
 Title: Client for the 'Alteryx Promote' API
-Version: 1.0.2
+Version: 1.1.0
 Date: 2018-04-20    
 Author: Paul E. Promote <promotedev@alteryx.com>
 Maintainer: Paul E. Promote <promotedev@alteryx.com>
@@ -16,4 +16,5 @@ Imports:
     jsonlite,
     stringr,
 License: FreeBSD
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
+Encoding: UTF-8

--- a/R/deps.R
+++ b/R/deps.R
@@ -19,19 +19,17 @@ add.dependency <- function(name, importName, src, version, install, auth_token, 
     version <- NA
   }
 
-  # Don't add the dependency if it's already there
-  
-  # New plan: apply function with a callback that either adds the new row or updates the fields on an existing one
-  # this will need to take importName into account, since a link could have changed (maybe different deploy key after one expires) resulting in dupes
+  # Don't add the dependency if it's already there, but if a package with the same importName is present,
+  # make sure to enter the most recent arguments in case of branch or name update
 
   dependencies <- promote$dependencies
+
   if (!any(dependencies$importName == importName)) {
     newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   } else {
-    # ind <- which(dependencies$importName == importName)
-    dependencies <- subset(dependencies, importName != importName)
+    dependencies <- dependencies[importName != importName, ]
     newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies

--- a/R/deps.R
+++ b/R/deps.R
@@ -8,7 +8,7 @@
 #' @param install whether or not the package should be installed in the model image
 #' @param auth_token a personal access token for github or gitlab repositories
 
-add.dependency <- function(name, importName, src, version, install, auth_token) {
+add.dependency <- function(name, importName, src, version, install, auth_token, branch) {
   # nulls will break the data.frame/rbind 
   # but we don't want to pass a version or auth token if not necessary
   if (is.null(auth_token)) {
@@ -19,10 +19,14 @@ add.dependency <- function(name, importName, src, version, install, auth_token) 
     version <- NA
   }
 
+   if (is.null(branch)) {
+    branch <- NA
+  }
+
   # Don't add the dependency if it's already there
   dependencies <- promote$dependencies
   if (!any(dependencies$name == name)) {
-    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token)
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -7,9 +7,9 @@
 #' @param version version of the package
 #' @param install whether or not the package should be installed in the model image
 #' @param auth_token a personal access token for github or gitlab repositories
-#' @param branch The branch or tag of the package to be installed
+#' @param ref The git branch, tag, or SHA of the package to be installed
 
-add.dependency <- function(name, importName, src, version, install, auth_token, branch) {
+add.dependency <- function(name, importName, src, version, install, auth_token, ref) {
   # nulls will break the data.frame/rbind 
   # but we don't want to pass a version or auth token if not necessary
   if (is.null(auth_token)) {
@@ -20,26 +20,26 @@ add.dependency <- function(name, importName, src, version, install, auth_token, 
     version <- NA
   }
 
-   if (is.null(branch)) {
+   if (is.null(ref)) {
     version <- NA
   }
 
   if (src == "version") {
-    branch <- NA
+    ref <- NA
   }
 
   # Don't add the dependency if it's already there, but if a package with the same importName is present,
-  # make sure to enter the most recent arguments in case of branch or name update
+  # make sure to enter the most recent arguments in case of ref or name update
 
   dependencies <- promote$dependencies
 
   if (!any(dependencies$importName == importName)) {
-    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, ref = ref)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   } else {
     dependencies <- dependencies[importName != importName, ]
-    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, ref = ref)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -6,11 +6,23 @@
 #' @param src source that the package is installed from (CRAN or github)
 #' @param version version of the package
 #' @param install whether or not the package should be installed in the model image
-add.dependency <- function(name, importName, src, version, install) {
+#' @param auth_token a personal access token for github or gitlab repositories
+
+add.dependency <- function(name, importName, src, version, install, auth_token) {
+  # nulls will break the data.frame/rbind 
+  # but we don't want to pass a version or auth token if not necessary
+  if (is.null(auth_token)) {
+    auth_token <- NA
+  }
+
+  if (is.null(version)) {
+    version <- NA
+  }
+
   # Don't add the dependency if it's already there
   dependencies <- promote$dependencies
   if (!any(dependencies$name == name)) {
-    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install)
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -19,13 +19,19 @@ add.dependency <- function(name, importName, src, version, install, auth_token, 
     version <- NA
   }
 
-   if (is.null(branch)) {
-    branch <- NA
-  }
-
   # Don't add the dependency if it's already there
+  
+  # New plan: apply function with a callback that either adds the new row or updates the fields on an existing one
+  # this will need to take importName into account, since a link could have changed (maybe different deploy key after one expires) resulting in dupes
+
   dependencies <- promote$dependencies
-  if (!any(dependencies$name == name)) {
+  if (!any(dependencies$importName == importName)) {
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
+    dependencies <- rbind(dependencies, newRow)
+    promote$dependencies <- dependencies
+  } else {
+    # ind <- which(dependencies$importName == importName)
+    dependencies <- subset(dependencies, importName != importName)
     newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, branch = branch)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies

--- a/R/deps.R
+++ b/R/deps.R
@@ -19,6 +19,14 @@ add.dependency <- function(name, importName, src, version, install, auth_token, 
     version <- NA
   }
 
+   if (is.null(branch)) {
+    version <- NA
+  }
+
+  if (src == "version") {
+    branch <- NA
+  }
+
   # Don't add the dependency if it's already there, but if a package with the same importName is present,
   # make sure to enter the most recent arguments in case of branch or name update
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -7,7 +7,7 @@
 #' @param version version of the package
 #' @param install whether or not the package should be installed in the model image
 #' @param auth_token a personal access token for github or gitlab repositories
-#' @param branch The branch of the package to be installed
+#' @param branch The branch or tag of the package to be installed
 
 add.dependency <- function(name, importName, src, version, install, auth_token, branch) {
   # nulls will break the data.frame/rbind 

--- a/R/deps.R
+++ b/R/deps.R
@@ -7,6 +7,7 @@
 #' @param version version of the package
 #' @param install whether or not the package should be installed in the model image
 #' @param auth_token a personal access token for github or gitlab repositories
+#' @param branch The branch of the package to be installed
 
 add.dependency <- function(name, importName, src, version, install, auth_token, branch) {
   # nulls will break the data.frame/rbind 

--- a/R/promote.R
+++ b/R/promote.R
@@ -150,12 +150,12 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' promote.library("my_proprietary_package", install=FALSE)
 #' }
 #' @importFrom utils packageDescription
-promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL) {
+promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL) {
 
   # If a vector of CRAN packages is passed, add each of them
   if (length(name) > 1) {
     for (n in name) {
-      promote.library(n, src=src, version=version, user=user, install=install, auth_token=auth_token)
+      promote.library(n, src=src, version=version, user=user, install=install, auth_token=auth_token, url=url)
     }
     return()
   }
@@ -166,21 +166,24 @@ promote.library <- function(name, src="version", version=NULL, user=NULL, instal
   }
 
   # Make sure it's using an accepted src
-  if (!src %in% c("version", "CRAN", "github", "gitlab", "bitbucket")) {
+  if (!src %in% c("version", "github", "git")) {
     stop(cat(src, "is not a valid package type"))
   }
 
 # This is to support the legacy implementation of github (public only) installs
-  if (!grepl("/", name) && src %in% c("github", "gitlab", "bitbucket")) {
+  if (!grepl("/", name) && src == "github") {
     if (is.null(user)) {
       stop(cat("no repository username specified"))
     }
     installName <- paste(user, "/", name, sep="")
+  } else if (src == "git") {
+    installName <- url
   } else {
     installName <- name
   }
 
-  if (grepl("/", name)) {
+# Also legacy code, but since we are now accepting github links for src='git' this grepl on it's own isn't enough
+  if (grepl("/", name) && src == "github") {
     nameAndUser <- unlist(strsplit(name, "/"))
     user <- nameAndUser[[1]]
     name <- nameAndUser[[2]]

--- a/R/promote.R
+++ b/R/promote.R
@@ -138,7 +138,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' @param user Github username associated with the package
 #' @param url A valid URL pointing to a remote hosted git repository
 #' @param auth_token Personal access token string associated with a private package's repository
-#' @param ref The branch, tag, or SHA of the package to be installed
+#' @param ref The git branch, tag, or SHA of the package to be installed
 #' @param install Whether the package should also be installed into the model on the
 #' Promote server; this is typically set to False when the package has already been
 #' added to the Promote base image.

--- a/R/promote.R
+++ b/R/promote.R
@@ -138,7 +138,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' @param user Github username associated with the package
 #' @param url A valid URL pointing to a remote hosted git repository
 #' @param auth_token Personal access token string associated with a private package's repository
-#' @param branch The branch of the package to be installed
+#' @param branch The branch or tag of the package to be installed
 #' @param install Whether the package should also be installed into the model on the
 #' Promote server; this is typically set to False when the package has already been
 #' added to the Promote base image.

--- a/R/promote.R
+++ b/R/promote.R
@@ -150,7 +150,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' promote.library("my_proprietary_package", install=FALSE)
 #' }
 #' @importFrom utils packageDescription
-promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, branch=NULL) {
+promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, branch="master") {
 
   # If a vector of CRAN packages is passed, add each of them
   if (length(name) > 1) {

--- a/R/promote.R
+++ b/R/promote.R
@@ -136,6 +136,9 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' @param src source from which the package will be installed on Promote (github or CRAN)
 #' @param version version of the package to be added
 #' @param user Github username associated with the package
+#' @param url A valid URL pointing to a remote hosted git repository
+#' @param auth_token Personal access token string associated with a private package's repository
+#' @param branch The branch of the package to be installed
 #' @param install Whether the package should also be installed into the model on the
 #' Promote server; this is typically set to False when the package has already been
 #' added to the Promote base image.

--- a/R/promote.R
+++ b/R/promote.R
@@ -150,12 +150,12 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' promote.library("my_proprietary_package", install=FALSE)
 #' }
 #' @importFrom utils packageDescription
-promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL) {
+promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, branch=NULL) {
 
   # If a vector of CRAN packages is passed, add each of them
   if (length(name) > 1) {
     for (n in name) {
-      promote.library(n, src=src, version=version, user=user, install=install, auth_token=auth_token, url=url)
+      promote.library(n, src=src, version=version, user=user, install=install, auth_token=auth_token, url=url, branch=NULL)
     }
     return()
   }
@@ -196,7 +196,7 @@ promote.library <- function(name, src="version", version=NULL, user=NULL, instal
     version <- packageDescription(name)$Version
   }
 
-  add.dependency(installName, name, src, version, install, auth_token)
+  add.dependency(installName, name, src, version, install, auth_token, branch)
 
   set.model.require()
 }

--- a/R/promote.R
+++ b/R/promote.R
@@ -151,11 +151,16 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' promote.library("hilaryparker/cats")
 #' promote.library("cats", src="github", user="hilaryparker")
 #' promote.library("my_public_package", install=FALSE)
-#' promote.library("my_public_package", src="git", url="https://gitlab.com/userName/repoName.git")
+#' promote.library("my_public_package", src="git", url="https://gitlab.com/userName/rpkg.git")
 #' promote.library("my_proprietary_package", src="github", auth_token=<yourToken>) 
 #' promote.library("testPkg", src="github", user="emessess", auth_token=<yourToken>) 
-#' promote.library("my_proprietary_package", src="git", url="https://x-access-token:<yourPersonalAccessToken>ATgithub.com/username/repoName.git")
-#' promote.library("my_proprietary_package", src="git", url="https://x-access-token:<yourPersonalAccessToken>ATgitlab.com/username/repoName.git", branch="desiredBranch")
+#' promote.library("priv_pkg", 
+#'                 src="git", 
+#'                 url="https://x-access-token:<PersonalAccessToken>ATgithub.com/username/rpkg.git")
+#' promote.library("priv_pkg", 
+#'                  src="git", 
+#'                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
+#'                  branch="stage")
 #' }
 #' @importFrom utils packageDescription
 promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, branch="master") {

--- a/R/promote.R
+++ b/R/promote.R
@@ -148,9 +148,14 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' \dontrun{
 #' promote.library("MASS")
 #' promote.library(c("wesanderson", "stringr"))
-#' promote.library("cats", src="github", user="hilaryparker")
 #' promote.library("hilaryparker/cats")
-#' promote.library("my_proprietary_package", install=FALSE)
+#' promote.library("cats", src="github", user="hilaryparker")
+#' promote.library("my_public_package", install=FALSE)
+#' promote.library("my_public_package", src="git", url="https://gitlab.com/userName/repoName.git")
+#' promote.library("my_proprietary_package", src="github", auth_token=<yourToken>) 
+#' promote.library("testPkg", src="github", user="emessess", auth_token=<yourToken>) 
+#' promote.library("my_proprietary_package", src="git", url="https://x-access-token:<yourPersonalAccessToken>ATgithub.com/username/repoName.git")
+#' promote.library("my_proprietary_package", src="git", url="https://x-access-token:<yourPersonalAccessToken>ATgitlab.com/username/repoName.git", branch="desiredBranch")
 #' }
 #' @importFrom utils packageDescription
 promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, branch="master") {

--- a/R/promote.R
+++ b/R/promote.R
@@ -138,7 +138,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' @param user Github username associated with the package
 #' @param url A valid URL pointing to a remote hosted git repository
 #' @param auth_token Personal access token string associated with a private package's repository
-#' @param branch The branch or tag of the package to be installed
+#' @param ref The branch, tag, or SHA of the package to be installed
 #' @param install Whether the package should also be installed into the model on the
 #' Promote server; this is typically set to False when the package has already been
 #' added to the Promote base image.
@@ -160,15 +160,15 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' promote.library("priv_pkg", 
 #'                  src="git", 
 #'                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
-#'                  branch="stage")
+#'                  ref="stage")
 #' }
 #' @importFrom utils packageDescription
-promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, branch="master") {
+promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master") {
 
   # If a vector of CRAN packages is passed, add each of them
   if (length(name) > 1) {
     for (n in name) {
-      promote.library(n, src=src, version=version, user=user, install=install, auth_token=auth_token, url=url, branch=NULL)
+      promote.library(n, src=src, version=version, user=user, install=install, auth_token=auth_token, url=url, ref=NULL)
     }
     return()
   }
@@ -209,7 +209,7 @@ promote.library <- function(name, src="version", version=NULL, user=NULL, instal
     version <- packageDescription(name)$Version
   }
 
-  add.dependency(installName, name, src, version, install, auth_token, branch)
+  add.dependency(installName, name, src, version, install, auth_token, ref)
 
   set.model.require()
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Altery Promote R Client
+# Alteryx Promote R Client
 R package for deploying models buiult using R to Altery Promote
 
 ### Installation
@@ -143,8 +143,8 @@ Tell the Promote servers to install a package needed to run `model.predict()`
 - `user`	Github username associated with the package
 - `install`	Whether the package should also be installed into the model on the Promote server; this is typically set to False when the package has already been added to the Promote base image.
 - `auth_token` Personal access token string associated with a private package's repository (only works when `src='github'`, reccommended usage is to include PAT in the URL parameter while using `src='git'`)
-- `url` A valid URL pointing to a remote hosted git repository
-- `ref`	The git branch, tag, or SHA of the package to be installed
+- `url` A valid URL pointing to a remote hosted git repository (recommended)
+- `ref`	The git branch, tag, or SHA of the package to be installed (SHA recommended)
 
 #### Examples
 
@@ -152,21 +152,25 @@ Public Repositories:
 ```r
 promote.library("randomforest")
 promote.library(c("wesanderson", "stringr"))
-promote.library("hilaryparker/cats")
-promote.library("cats", src="github", user="hilaryparker")
 promote.library("my_public_package", install=FALSE)
 promote.library("my_public_package", src="git", url="https://gitlab.com/userName/rpkg.git")
+promote.library("hilaryparker/cats")
+promote.library("cats", src="github", user="hilaryparker")
 ```
 
 Private Repositories:
 ```r
-promote.library("my_proprietary_package", src="github", auth_token=<yourToken>) 
-promote.library("testPkg", src="github", user="emessess", auth_token=<yourToken>) 
 promote.library("priv_pkg", 
                 src="git", 
                 url="https://x-access-token:<PersonalAccessToken>ATgithub.com/username/rpkg.git")
 promote.library("priv_pkg", 
                  src="git", 
                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
-                 ref="stage")
+                 ref="i2706b2a9f0c2f80f9c2a90ac4499a80280b3f8d")
+promote.library("priv_pkg", 
+                 src="git", 
+                 url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
+                 ref="staging")
+promote.library("cats", src="github", user="hilaryparker", auth_token=<yourToken>) 
+
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Before beginning building a model, be sure to import the `promote` package:
 
 ### The `model.predict()` function
 
-The `model.predict` function is used o define the API endpoint for a model and is executed each time a model is called. **This is the core of the API endpoint**
+The `model.predict` function is used to define the API endpoint for a model and is executed each time a model is called. **This is the core of the API endpoint**
 
 ```r
 # import the promote package and define our model function
@@ -133,15 +133,40 @@ Tell the Promote servers to install a package needed to run `model.predict()`
 
 #### Usage
 
-`promote.library(package)`
+`promote.library(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master")`
 
 #### Arguments
 
-- 'package'(_string_): the name of the package to install on the Promoter server
+ - `name`	name of the package to be added
+- `src`	source from which the package will be installed on Promote (CRAN (version) or git)
+- `version`	version of the package to be added
+- `user`	Github username associated with the package
+- `install`	Whether the package should also be installed into the model on the Promote server; this is typically set to False when the package has already been added to the Promote base image.
+- `auth_token` Personal access token string associated with a private package's repository (only works when `src='github'`, reccommended usage is to include PAT in the URL parameter while using `src='git'`)
+- `url` A valid URL pointing to a remote hosted git repository
+- `ref`	The git branch, tag, or SHA of the package to be installed
 
 #### Examples
 
+Public Repositories:
 ```r
 promote.library("randomforest")
-promote.library("plyr")
+promote.library(c("wesanderson", "stringr"))
+promote.library("hilaryparker/cats")
+promote.library("cats", src="github", user="hilaryparker")
+promote.library("my_public_package", install=FALSE)
+promote.library("my_public_package", src="git", url="https://gitlab.com/userName/rpkg.git")
+```
+
+Private Repositories:
+```r
+promote.library("my_proprietary_package", src="github", auth_token=<yourToken>) 
+promote.library("testPkg", src="github", user="emessess", auth_token=<yourToken>) 
+promote.library("priv_pkg", 
+                src="git", 
+                url="https://x-access-token:<PersonalAccessToken>ATgithub.com/username/rpkg.git")
+promote.library("priv_pkg", 
+                 src="git", 
+                 url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
+                 ref="stage")
 ```

--- a/README.md
+++ b/README.md
@@ -1,176 +1,232 @@
 # Alteryx Promote R Client
-R package for deploying models buiult using R to Altery Promote
+Package for deploying R models to Alteryx Promote.
 
-### Installation
+### Examples:
+[Hello World](examples/helloworld) - A very simple model.
 
+[Lending](examples/lending) - Use logistic regression to classify credit applications. as good or bad.
+
+[xgboost](examples/xgboost) - Use xgboost to train a classifier on the agaricus dataset.
+<hr>
+
+## Installation
+### Client
+To install the promote package from CRAN, execute the following code from an active R session:
 ```r
 install.packages("promote")
 ```
 
-### Example Models
-[Hello World](examples/helloworld) - a very simple model
+(Please refer to the [promote-python](https://github.com/alteryx/promote-python) package for instructions on installing the Python client.)
 
-[Lending](examples/lending) - Use logistic regression to classify credit applications as good or bad
+### Promote App
+Please refer to the [installation guide](https://help.alteryx.com/promote/current/Administer/Installation.htm?tocpath=Administer%7C_____2) for instructions on installing the full Promote application.
+<hr>
 
-[xgboost](examples/xgboost) - Use xgboost to train a classifier on the agaricus dataset
-
-### Project Overview
-
-In order for all of your model dependencies to be transfered over to Alteryx Promote, you must follow a particular structure.
-
-#### Example model directory structure:
+## Using the Client
+### Model Directory Structure
 ```
 example-model/
-├── promote.sh
-└── main.R (our deployment script)
+├── deploy.R
+└── promote.sh (optional)
 ```
 
-`promote.sh` - this file is executed before your model is built. It can be used to install low-level system packages such as Linux packages
+- [`deploy.R`](#deployr): our primary model deployment script
 
-`main.R` - our primary model deployment script
+- [`promote.sh`](#promotesh): this file is executed before your model is built. It can be used to install low-level system packages such as Linux packages
+<hr>
 
-## Building a model:
+## Deploying Your Model
 
-Before beginning building a model, be sure to import the `promote` package:
+This section will walk through the steps and key functions of a successful `deploy.r` script. 
+#### Steps:
+- [Initial Setup](#setup)
+- [model.predict](#modelpredict)
+- [Test Data](#testing)
+- [promote.library](#promotelibrary)
+- [promote.metadata](#promotemetadata)
+- [promote.config](#promoteconfig)
+- [promote.deploy](#promotedeploy)
+<hr>
 
-`libary(promote)`
+### <a name="setup"></a>Initial Setup
+Load the `promote` library that was previously installed:
+```r
+library(promote)
+```
 
-### The `model.predict()` function
+Import a saved model object:
+```r
+# Previously saved model 'save(my_model, file = "my_model.rda")'
+load("my_model.rda")
+```
+<hr>
 
+### `model.predict`
 The `model.predict` function is used to define the API endpoint for a model and is executed each time a model is called. **This is the core of the API endpoint**
 
-```r
-# import the promote package and define our model function
-library(promote)
+### Usage
+`model.predict(data)`
 
-model.predict <- function(request) {
-  me <- request$name
-  greeting <- paste0("Hello", me, "!")
-  greeting
+### Arguments
+- `data` the data frame generated from the JSON sent to the deployed model
+
+**Example:**
+```r
+model.predict <- function(data) {
+  # generate predictions from the model based on the incoming dataframe
+  predict(my_model, data)
 }
-
-# add metadata to attach to this model version
-promote.metadata("NAME1",value1)
-promote.metadata("NAME2",value2)
-
-# specify the username, apikey and url, and then deploy
-promote.config  <- c(
-  username = "YOUR_USERNAME",
-  apikey = "YOUR_API_KEY",
-  env = "PROMOTE_URL"
-)
-
-promote.deploy("HelloWorld", confirm = FALSE)
 ```
 
-<hr>
+### <a name="testing"></a>Test Data
+It is a good practice to test the `model.predict` function as part of the deployment script to make sure it successfully produces an output. Once deployed, the `data` argument passed to the `model.predict` function will always be in the form of an R [data frame](https://stat.ethz.ch/R-manual/R-devel/library/base/html/data.frame.html). The incoming JSON will be converted to a data frame using the `fromJSON()` method available from either [jsonlite](https://cran.r-project.org/web/packages/jsonlite/jsonlite.pdf) or [rjson](https://cran.r-project.org/web/packages/rjson/rjson.pdf). Which library is used can be configured in the advanced model management section of the Promote App.
 
-### Setting the Auth
-
-To deploy models, you'll need to add your username, API key, and URL to the `promote.config` variable
+**Example:**
 ```r
-promote.config <- c(
-  username = [USERNAME],
-  apikey = [APIKEY],
-  env = [URL]
-)
+testdata <- '{"X1":[1,2,3],"X2":[4,5,6]}'
+model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
+
 ```
 <hr>
 
-### `Promote`
+### `promote.library`
 
-The `Promote` packages has 3 methods:
-- [`promote.deploy`](#promotedeploy)
-- [`promote.metadata`](#promotemetadata)
-- [`promote.library`](#promotelibrary)
+### Usage
 
-### `promote.deploy()`
+`promote.library(name, src = "version", version = NULL, user = NULL, install = TRUE, auth_token = NULL, url = NULL, ref = "master")`
 
-#### Deploy a model to Alteryx Promote
-
-The `deploy function captures `model.predict()` and the `promote.sh` file and sends them to the Promote servers
-
-#### Usage
-
-`promote.deploy(name,confirm=False)
-
-#### Arguments
-- `name`(_string_): the name of the model to deploy to Alteryx Promote
-- `confirm`(_boolean_, optional): If `TRUE`, then user will be prompted to confirm deployment
-
-#### Examples
-
-Deploy the "IrisClassifier_model" and don't require confirmation on deployment.
-```r
-promote.deploy("IrisClassifier_model",confirm=FALSE)
-```
-<hr>
-
-### `promote.metadata()`
-
-Store custom metadta about amoel as part of the `model.predict()` when it is sent to the Promote servers. (limited to 6 key-value pairs)
-
-#### Usage
-
-`promote.metadata(name, value)`
-
-#### Arguments
-- `name`(_string_): the name of your metadata (limit 20 characters)
-- `value`: a value for your metadata (will be converted to string and limited to 50 characters)
-
-#### Examples
-
-```r
-promote.metadata("one", 1)
-promote.metadata("two","2")
-promote.metadata("list",list(a=1,b=2))
-```
-<hr>
-
-### `promote.library()`
-
-Tell the Promote servers to install a package needed to run `model.predict()`
-
-#### Usage
-
-`promote.library(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master")`
-
-#### Arguments
+### Arguments
 
  - `name`	name of the package to be added
 - `src`	source from which the package will be installed on Promote (CRAN (version) or git)
 - `version`	version of the package to be added
 - `user`	Github username associated with the package
-- `install`	Whether the package should also be installed into the model on the Promote server; this is typically set to False when the package has already been added to the Promote base image.
-- `auth_token` Personal access token string associated with a private package's repository (only works when `src='github'`, reccommended usage is to include PAT in the URL parameter while using `src='git'`)
+- `install`	whether the package should also be installed into the model on the Promote server; this is typically set to False when the package has already been added to the Promote base image.
+- `auth_token` Personal access token string associated with a private package's repository (only works when `src = 'github'`, recommended usage is to include PAT in the URL parameter while using `src='git'`)
 - `url` A valid URL pointing to a remote hosted git repository (recommended)
 - `ref`	The git branch, tag, or SHA of the package to be installed (SHA recommended)
 
-#### Examples
+**Examples:**
 
 Public Repositories:
 ```r
 promote.library("randomforest")
+
 promote.library(c("wesanderson", "stringr"))
-promote.library("my_public_package", install=FALSE)
-promote.library("my_public_package", src="git", url="https://gitlab.com/userName/rpkg.git")
+
+promote.library("my_public_package", install = FALSE)
+
+promote.library("my_public_package", 
+                src = "git", 
+                url = "https://gitlab.com/userName/rpkg.git")
+
 promote.library("hilaryparker/cats")
-promote.library("cats", src="github", user="hilaryparker")
+
+promote.library("cats", src = "github", user = "hilaryparker")
 ```
 
 Private Repositories:
 ```r
 promote.library("priv_pkg", 
-                src="git", 
-                url="https://x-access-token:<PersonalAccessToken>ATgithub.com/username/rpkg.git")
-promote.library("priv_pkg", 
-                 src="git", 
-                 url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
-                 ref="i2706b2a9f0c2f80f9c2a90ac4499a80280b3f8d")
-promote.library("priv_pkg", 
-                 src="git", 
-                 url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
-                 ref="staging")
-promote.library("cats", src="github", user="hilaryparker", auth_token=<yourToken>) 
+                src = "git", 
+                url = "https://x-access-token:<YourToken>ATgithub.com/username/rpkg.git")
 
+promote.library("priv_pkg", 
+                 src = "git", 
+                 url = "https://x-access-token:<YourToken>ATgitlab.com/username/rpkg.git", 
+                 ref = "i2706b2a9f0c2f80f9c2a90ac4499a80280b3f8d")
+
+promote.library("priv_pkg", 
+                 src = "git", 
+                 url = "https://x-access-token:<YourToken>ATgitlab.com/username/rpkg.git", 
+                 ref = "staging")
+
+promote.library("cats", src = "github", user = "hilaryparker", auth_token = "3HwjSeMu1ynrYtc1e4yj") 
 ```
+<hr>
+
+
+### `promote.metadata`
+Store custom metadata about a model as part of the `model.predict` call when it is sent to the Promote servers. (limited to 6 key-value pairs)
+
+### Usage
+`promote.metadata(name, value)`
+
+### Arguments
+- `name` the name of your metadata (limit 20 characters)
+- `value` a value for your metadata (will be converted to string and limited to 50 characters)
+
+**Example:**
+```r
+promote.metadata("one", 1)
+promote.metadata("two", "2")
+promote.metadata("list", list(a=1,b=2))
+```
+<hr>
+
+### `promote.config`
+To deploy models, add a username, API key, and URL to the `promote.config` variable
+
+- `username` the username used to sign into the Promote app
+- `apikey` the random API key that is assigned to that username
+- `env` the URL that can be used to access the Promote app's frontend
+
+**Example:**
+```r
+promote.config <- c(
+  username = "username",
+  apikey = "apikey",
+  env = "http://promote.company.com/"
+)
+```
+<hr>
+
+### `promote.deploy`
+The deploy function captures `model.predict` and the `promote.sh` file and sends them to the Promote servers
+
+### Usage
+`promote.deploy(model_name, confirm = TRUE, custom_image = NULL)`
+
+### Arguments
+- `model_name` the name of the model to deploy to Alteryx Promote
+- `confirm` if true, the user will be prompted to confirm deployment 
+- `custom_image` the custom image tag to use when building the model
+
+**Example:**
+```r
+promote.deploy("MyFirstRModel", confirm = TRUE, custom_image = NULL)
+```
+<hr>
+
+### `promote.sh`
+The `promote.sh` file can be included in your model directory. It is executed before your model is built and can be used to install low-level system packages such as Linux packages and other dependencies. Be aware of the current working directory for your R session when deploying to ensure the deployment finds and processes the `promote.sh` file.
+
+**Example:**
+```shell
+# Install Microsoft SQL Server RHEL7 ODBC Driver
+curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
+
+exit
+yum remove unixODBC-utf16 unixODBC-utf16-devel #to avoid conflicts
+ACCEPT_EULA=Y yum install msodbcsql17
+# optional: for bcp and sqlcmd
+ACCEPT_EULA=Y yum install mssql-tools
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+source ~/.bashrc
+```
+<hr>
+
+### Deployment
+There are multiple ways to run your `deploy.R` script and deploy your model.
+1. In in an active R shell session, you can source the deploy.R file.
+```r
+source("deploy.R")
+```
+
+2. If in a console/terminal/bash session, you can use the `Rscript` utility to run the file.
+```shell
+Rscript deploy.R
+```
+
+3. If using an R IDE environment like [RStudio](https://www.rstudio.com/), you can run or source the script all at once or selectively. Model deployment will once the `promote.deploy` function is called.

--- a/man/add.dependency.Rd
+++ b/man/add.dependency.Rd
@@ -21,7 +21,7 @@ this may be different from the name used to install it)}
 
 \item{auth_token}{a personal access token for github or gitlab repositories}
 
-\item{branch}{The branch of the package to be installed}
+\item{branch}{The branch or tag of the package to be installed}
 }
 \description{
 Private function that adds a package to the list of dependencies

--- a/man/add.dependency.Rd
+++ b/man/add.dependency.Rd
@@ -5,7 +5,7 @@
 \title{Private function that adds a package to the list of dependencies
 that will be installed on the Promote server}
 \usage{
-add.dependency(name, importName, src, version, install)
+add.dependency(name, importName, src, version, install, auth_token, branch)
 }
 \arguments{
 \item{name}{name of the package to be installed}
@@ -18,6 +18,10 @@ this may be different from the name used to install it)}
 \item{version}{version of the package}
 
 \item{install}{whether or not the package should be installed in the model image}
+
+\item{auth_token}{a personal access token for github or gitlab repositories}
+
+\item{branch}{The branch of the package to be installed}
 }
 \description{
 Private function that adds a package to the list of dependencies

--- a/man/add.dependency.Rd
+++ b/man/add.dependency.Rd
@@ -5,7 +5,7 @@
 \title{Private function that adds a package to the list of dependencies
 that will be installed on the Promote server}
 \usage{
-add.dependency(name, importName, src, version, install, auth_token, branch)
+add.dependency(name, importName, src, version, install, auth_token, ref)
 }
 \arguments{
 \item{name}{name of the package to be installed}
@@ -21,7 +21,7 @@ this may be different from the name used to install it)}
 
 \item{auth_token}{a personal access token for github or gitlab repositories}
 
-\item{branch}{The branch or tag of the package to be installed}
+\item{ref}{The git branch, tag, or SHA of the package to be installed}
 }
 \description{
 Private function that adds a package to the list of dependencies

--- a/man/promote.library.Rd
+++ b/man/promote.library.Rd
@@ -25,7 +25,7 @@ added to the Promote base image.}
 
 \item{url}{A valid URL pointing to a remote hosted git repository}
 
-\item{branch}{The branch of the package to be installed}
+\item{branch}{The branch or tag of the package to be installed}
 }
 \description{
 Import one or more libraries and add them to the promote model's

--- a/man/promote.library.Rd
+++ b/man/promote.library.Rd
@@ -25,7 +25,7 @@ added to the Promote base image.}
 
 \item{url}{A valid URL pointing to a remote hosted git repository}
 
-\item{ref}{The branch, tag, or SHA of the package to be installed}
+\item{ref}{The git branch, tag, or SHA of the package to be installed}
 }
 \description{
 Import one or more libraries and add them to the promote model's

--- a/man/promote.library.Rd
+++ b/man/promote.library.Rd
@@ -6,7 +6,7 @@
 dependency list}
 \usage{
 promote.library(name, src = "version", version = NULL, user = NULL,
-  install = TRUE, auth_token = NULL, url = NULL, branch = "master")
+  install = TRUE, auth_token = NULL, url = NULL, ref = "master")
 }
 \arguments{
 \item{name}{name of the package to be added}
@@ -25,7 +25,7 @@ added to the Promote base image.}
 
 \item{url}{A valid URL pointing to a remote hosted git repository}
 
-\item{branch}{The branch or tag of the package to be installed}
+\item{ref}{The branch, tag, or SHA of the package to be installed}
 }
 \description{
 Import one or more libraries and add them to the promote model's
@@ -47,7 +47,7 @@ promote.library("priv_pkg",
 promote.library("priv_pkg", 
                  src="git", 
                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
-                 branch="stage")
+                 ref="stage")
 }
 }
 \keyword{import}

--- a/man/promote.library.Rd
+++ b/man/promote.library.Rd
@@ -35,9 +35,19 @@ dependency list
 \dontrun{
 promote.library("MASS")
 promote.library(c("wesanderson", "stringr"))
-promote.library("cats", src="github", user="hilaryparker")
 promote.library("hilaryparker/cats")
-promote.library("my_proprietary_package", install=FALSE)
+promote.library("cats", src="github", user="hilaryparker")
+promote.library("my_public_package", install=FALSE)
+promote.library("my_public_package", src="git", url="https://gitlab.com/userName/rpkg.git")
+promote.library("my_proprietary_package", src="github", auth_token=<yourToken>) 
+promote.library("testPkg", src="github", user="emessess", auth_token=<yourToken>) 
+promote.library("priv_pkg", 
+                src="git", 
+                url="https://x-access-token:<PersonalAccessToken>ATgithub.com/username/rpkg.git")
+promote.library("priv_pkg", 
+                 src="git", 
+                 url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
+                 branch="stage")
 }
 }
 \keyword{import}

--- a/man/promote.library.Rd
+++ b/man/promote.library.Rd
@@ -5,8 +5,8 @@
 \title{Import one or more libraries and add them to the promote model's
 dependency list}
 \usage{
-promote.library(name, src = "CRAN", version = NULL, user = NULL,
-  install = TRUE)
+promote.library(name, src = "version", version = NULL, user = NULL,
+  install = TRUE, auth_token = NULL, url = NULL, branch = "master")
 }
 \arguments{
 \item{name}{name of the package to be added}
@@ -20,6 +20,12 @@ promote.library(name, src = "CRAN", version = NULL, user = NULL,
 \item{install}{Whether the package should also be installed into the model on the
 Promote server; this is typically set to False when the package has already been
 added to the Promote base image.}
+
+\item{auth_token}{Personal access token string associated with a private package's repository}
+
+\item{url}{A valid URL pointing to a remote hosted git repository}
+
+\item{branch}{The branch of the package to be installed}
 }
 \description{
 Import one or more libraries and add them to the promote model's

--- a/man/promote.post.Rd
+++ b/man/promote.post.Rd
@@ -4,7 +4,8 @@
 \alias{promote.post}
 \title{Private function for performing a POST request}
 \usage{
-promote.post(endpoint, query = c(), data, silent = TRUE, bulk = FALSE)
+promote.post(endpoint, query = c(), data, silent = TRUE,
+  bulk = FALSE)
 }
 \arguments{
 \item{endpoint}{/path for REST request}

--- a/promote-r-client.Rproj
+++ b/promote-r-client.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
This PR adds additional package installation options via remote source control (public and private repositories) by updating `promote.library` to accept two additional, optional parameters, `auth_token` and `url` (when combined with correct options for the `src` parameter). The function now also accepts a `ref` parameter to allow users to target a specific branch, tag or SHA for the repository. 

 Here's the new signature:

`promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master")` 

If you want to install via any hosted version control source, you would do this (github url example):

`promote.deploy("testPkg", src="git" url="https://x-access-token:<yourPersonalAccessToken>@<host>/<username>/<packagename>.git")`

This is agnostic to which hosting service you're using, as long as the link is well formed. 

The way the client is currently set up, mainly on account of the preexisting github implementation, maintains both a "name" and an "installName", and name (once it hits `deps.R`) eventually actually becomes importName (basically the name used for the eventual `library()` call. This will make more sense after reading the following, since you can see that the "name" can be a username/repo format if `src="github"`:

For what I gather are legacy reasons, this also works , for github ONLY:

`promote.library("<username>/<packagename>", src="github", auth_token="<yourPersonalAccessToken>")`

You don't need an `auth_token` if the repository is public.

The user and name can be split into separate params if desired, client will take care of both cases:

`promote.library("testPkg", src="github", user="emessess" auth_token = "
<yourPersonalAccessToken>")`