### PR TITLE
Custom pkg subdirs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: promote
 Type: Package
 Title: Client for the 'Alteryx Promote' API
-Version: 1.1.0
+Version: 1.1.1
 Date: 2018-11-07    
 Author: Paul E. Promote <promotedev@alteryx.com>
 Maintainer: Paul E. Promote <promotedev@alteryx.com>

--- a/R/deps.R
+++ b/R/deps.R
@@ -8,8 +8,9 @@
 #' @param install whether or not the package should be installed in the model image
 #' @param auth_token a personal access token for github or gitlab repositories
 #' @param ref The git branch, tag, or SHA of the package to be installed
+#' @param subdir The path to the repo subdirectory holding the package to be installed
 
-add.dependency <- function(name, importName, src, version, install, auth_token, ref) {
+add.dependency <- function(name, importName, src, version, install, auth_token, ref, subdir) {
   # nulls will break the data.frame/rbind 
   # but we don't want to pass a version or auth token if not necessary
   if (is.null(auth_token)) {
@@ -20,7 +21,11 @@ add.dependency <- function(name, importName, src, version, install, auth_token, 
     version <- NA
   }
 
-   if (is.null(ref)) {
+  if (is.null(ref)) {
+    version <- NA
+  }
+
+  if (is.null(subdir)) {
     version <- NA
   }
 
@@ -34,12 +39,12 @@ add.dependency <- function(name, importName, src, version, install, auth_token, 
   dependencies <- promote$dependencies
 
   if (!any(dependencies$importName == importName)) {
-    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, ref = ref)
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, ref = ref, subdir = subdir)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   } else {
     dependencies <- dependencies[importName != importName, ]
-    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, ref = ref)
+    newRow <- data.frame(name = name, importName = importName, src = src, version = version, install = install, auth_token = auth_token, ref = ref, subdir = subdir)
     dependencies <- rbind(dependencies, newRow)
     promote$dependencies <- dependencies
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -11,30 +11,6 @@
 #' @param subdir The path to the repo subdirectory holding the package to be installed
 
 add.dependency <- function(name, importName, src, version, install, auth_token, ref, subdir) {
-  # nulls will break the data.frame/rbind 
-  # but we don't want to pass a version or auth token if not necessary
-
-  print(c(name, importName, src, version, install, auth_token, ref, subdir))
-  # if (is.null(auth_token)) {
-  #   auth_token <- NA
-  # }
-
-  # if (is.null(version)) {
-  #   version <- NA
-  # }
-
-  # if (is.null(ref)) {
-  #   version <- NA
-  # }
-
-  # if (is.null(subdir)) {
-  #   version <- NA
-  # }
-
-  # if (src == "version") {
-  #   ref <- NA
-  # }
-
   # Don't add the dependency if it's already there, but if a package with the same importName is present,
   # make sure to enter the most recent arguments in case of ref or name update
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -13,25 +13,27 @@
 add.dependency <- function(name, importName, src, version, install, auth_token, ref, subdir) {
   # nulls will break the data.frame/rbind 
   # but we don't want to pass a version or auth token if not necessary
-  if (is.null(auth_token)) {
-    auth_token <- NA
-  }
 
-  if (is.null(version)) {
-    version <- NA
-  }
+  print(c(name, importName, src, version, install, auth_token, ref, subdir))
+  # if (is.null(auth_token)) {
+  #   auth_token <- NA
+  # }
 
-  if (is.null(ref)) {
-    version <- NA
-  }
+  # if (is.null(version)) {
+  #   version <- NA
+  # }
 
-  if (is.null(subdir)) {
-    version <- NA
-  }
+  # if (is.null(ref)) {
+  #   version <- NA
+  # }
 
-  if (src == "version") {
-    ref <- NA
-  }
+  # if (is.null(subdir)) {
+  #   version <- NA
+  # }
+
+  # if (src == "version") {
+  #   ref <- NA
+  # }
 
   # Don't add the dependency if it's already there, but if a package with the same importName is present,
   # make sure to enter the most recent arguments in case of ref or name update

--- a/R/promote.R
+++ b/R/promote.R
@@ -139,6 +139,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #' @param url A valid URL pointing to a remote hosted git repository
 #' @param auth_token Personal access token string associated with a private package's repository
 #' @param ref The git branch, tag, or SHA of the package to be installed
+#' @param subdir The path to the repo subdirectory holding the package to be installed
 #' @param install Whether the package should also be installed into the model on the
 #' Promote server; this is typically set to False when the package has already been
 #' added to the Promote base image.
@@ -163,7 +164,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #'                  ref="stage")
 #' }
 #' @importFrom utils packageDescription
-promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master") {
+promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master", subdir=NULL) {
 
   # If a vector of CRAN packages is passed, add each of them
   if (length(name) > 1) {
@@ -209,7 +210,7 @@ promote.library <- function(name, src="version", version=NULL, user=NULL, instal
     version <- packageDescription(name)$Version
   }
 
-  add.dependency(installName, name, src, version, install, auth_token, ref)
+  add.dependency(installName, name, src, version, install, auth_token, ref, subdir)
 
   set.model.require()
 }

--- a/R/promote.R
+++ b/R/promote.R
@@ -162,6 +162,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #'                  src="git", 
 #'                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
 #'                  ref="stage")
+#' promote.library("my_proprietary_package", src="github", auth_token=<yourToken> subdir="/yourSubDirectory/")  
 #' }
 #' @importFrom utils packageDescription
 promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master", subdir=NULL) {

--- a/R/promote.R
+++ b/R/promote.R
@@ -162,7 +162,7 @@ promote.predict <- function(model_name, data, model_owner, raw_input = FALSE, si
 #'                  src="git", 
 #'                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
 #'                  ref="stage")
-#' promote.library("my_proprietary_package", src="github", auth_token=<yourToken> subdir="/yourSubDirectory/")  
+#' promote.library("my_package", src="github", auth_token=<yourToken> subdir="/pathToSubdir/")  
 #' }
 #' @importFrom utils packageDescription
 promote.library <- function(name, src="version", version=NULL, user=NULL, install=TRUE, auth_token=NULL, url=NULL, ref="master", subdir=NULL) {

--- a/R/promote.R
+++ b/R/promote.R
@@ -210,7 +210,12 @@ promote.library <- function(name, src="version", version=NULL, user=NULL, instal
     version <- packageDescription(name)$Version
   }
 
-  add.dependency(installName, name, src, version, install, auth_token, ref, subdir)
+  paramsList <- list(installName, name, src, version, install, auth_token, ref, subdir)
+  replacedNulls <- lapply(paramsList, function(x) ifelse(is.null(x), NA, x))
+
+  do.call(add.dependency, replacedNulls)
+
+  # add.dependency(installName, name, src, version, install, auth_token, ref, subdir)
 
   set.model.require()
 }

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
 
 `promote.library(name, src = "version", version = NULL, user = NULL, install = TRUE, auth_token = NULL, url = NULL, ref = "master", subdir = NULL)`
 
-**Note**: Installing custom packages from git requires Promote version 2018.4.1 or higher.
+**Note**: Installing custom packages from git requires Promote version 2018.4.1 or higher. Installing custom packages with `subdir` parameter requires Promote version 2019.1.0 or higher.
 
 ### Arguments
 
  - `name`	name of the package to be added
-- `src`	source from which the package will be installed on Promote (CRAN (version) or git)
-- `version`	version of the package to be added (CRAN only, use `ref` parameter for git packages )
+- `src`	source from which the package will be installed on Promote (CRAN or git)
+- `version`	version of the package to be added (CRAN only, use `ref` parameter for git packages)
 - `user`	Github username associated with the package
 - `install`	whether the package should also be installed into the model on the Promote server; this is typically set to False when the package has already been added to the Promote base image.
 - `auth_token` Personal access token string associated with a private package's repository (only works when `src = 'github'`, recommended usage is to include PAT in the URL parameter while using `src='git'`)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
 
 `promote.library(name, src = "version", version = NULL, user = NULL, install = TRUE, auth_token = NULL, url = NULL, ref = "master", subdir = NULL)`
 
+**Note**: Installing custom packages from git requires Promote version 2018.4.1 or higher.
+
 ### Arguments
 
  - `name`	name of the package to be added
@@ -105,7 +107,7 @@ model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
 - `auth_token` Personal access token string associated with a private package's repository (only works when `src = 'github'`, recommended usage is to include PAT in the URL parameter while using `src='git'`)
 - `url` A valid URL pointing to a remote hosted git repository (recommended)
 - `ref`	The git branch, tag, or SHA of the package to be installed (SHA recommended)
-- `subdir` The subdirectory of a git repository holding the package to install
+- `subdir` The subdirectory path of a git repository holding the package to install
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
 
 ### Usage
 
-`promote.library(name, src = "version", version = NULL, user = NULL, install = TRUE, auth_token = NULL, url = NULL, ref = "master")`
+`promote.library(name, src = "version", version = NULL, user = NULL, install = TRUE, auth_token = NULL, url = NULL, ref = "master", subdir = NULL)`
 
 ### Arguments
 
@@ -105,6 +105,7 @@ model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
 - `auth_token` Personal access token string associated with a private package's repository (only works when `src = 'github'`, recommended usage is to include PAT in the URL parameter while using `src='git'`)
 - `url` A valid URL pointing to a remote hosted git repository (recommended)
 - `ref`	The git branch, tag, or SHA of the package to be installed (SHA recommended)
+- `subdir` The subdirectory of a git repository holding the package to install
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ model.predict(data.frame(jsonlite::fromJSON(testdata),stringsAsFactors=TRUE))
 
  - `name`	name of the package to be added
 - `src`	source from which the package will be installed on Promote (CRAN (version) or git)
-- `version`	version of the package to be added
+- `version`	version of the package to be added (CRAN only, use `ref` parameter for git packages )
 - `user`	Github username associated with the package
 - `install`	whether the package should also be installed into the model on the Promote server; this is typically set to False when the package has already been added to the Promote base image.
 - `auth_token` Personal access token string associated with a private package's repository (only works when `src = 'github'`, recommended usage is to include PAT in the URL parameter while using `src='git'`)

--- a/man/add.dependency.Rd
+++ b/man/add.dependency.Rd
@@ -5,7 +5,8 @@
 \title{Private function that adds a package to the list of dependencies
 that will be installed on the Promote server}
 \usage{
-add.dependency(name, importName, src, version, install, auth_token, ref)
+add.dependency(name, importName, src, version, install, auth_token, ref,
+  subdir)
 }
 \arguments{
 \item{name}{name of the package to be installed}
@@ -22,6 +23,8 @@ this may be different from the name used to install it)}
 \item{auth_token}{a personal access token for github or gitlab repositories}
 
 \item{ref}{The git branch, tag, or SHA of the package to be installed}
+
+\item{subdir}{The path to the repo subdirectory holding the package to be installed}
 }
 \description{
 Private function that adds a package to the list of dependencies

--- a/man/promote.library.Rd
+++ b/man/promote.library.Rd
@@ -6,7 +6,8 @@
 dependency list}
 \usage{
 promote.library(name, src = "version", version = NULL, user = NULL,
-  install = TRUE, auth_token = NULL, url = NULL, ref = "master")
+  install = TRUE, auth_token = NULL, url = NULL, ref = "master",
+  subdir = NULL)
 }
 \arguments{
 \item{name}{name of the package to be added}
@@ -26,6 +27,8 @@ added to the Promote base image.}
 \item{url}{A valid URL pointing to a remote hosted git repository}
 
 \item{ref}{The git branch, tag, or SHA of the package to be installed}
+
+\item{subdir}{The path to the repo subdirectory holding the package to be installed}
 }
 \description{
 Import one or more libraries and add them to the promote model's
@@ -48,6 +51,7 @@ promote.library("priv_pkg",
                  src="git", 
                  url="https://x-access-token:<PersonalAccessToken>ATgitlab.com/username/rpkg.git", 
                  ref="stage")
+promote.library("my_package", src="github", auth_token=<yourToken> subdir="/pathToSubdir/")  
 }
 }
 \keyword{import}


### PR DESCRIPTION
This PR adds the ability to install a custom package from a subdirectory on a hosted git repository. For example, a DS team might have a big monorepo with subfolders for the different packages. The implementation to date did not support this, meaning users could only target a package in its own git repository.

It also refactors the handling of a `NULL <- NA` conversion that's important as NULLs from `promote.library` arguments make their way into the dataframe created in `add.dependency`. Previously there were only a couple optional parameters with default NULL and it was being done on as individual IFs in `add.dependency`. As custom package import added a number of optional params, we're going to construct a list and lapply NULLs to NAs in` promote.library` _before_ passing that to `add.dependency` now. Feels cleaner but open to discussion. 

The `subdir` parameter follows the conventions of `devtools::install_git`, i.e. receives a string representing the subdirectory's path relative to the main git directory. 